### PR TITLE
feat: add new event handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ export default class ReactInstrumentationPiano {
   get eventHandlers() {
     return {
       pageview: this.pageview.bind(this),
+      userinformationchange: this.userinformationchange.bind(this),
     };
   }
 
@@ -47,6 +48,10 @@ export default class ReactInstrumentationPiano {
           }
 
           return new Promise((resolve, reject) => {
+            if (this.config.preInit) {
+              this.config.preInit();
+            }
+
             window.tp.push([
               'init', () => {
                 try {
@@ -86,14 +91,28 @@ export default class ReactInstrumentationPiano {
   }
 
   /* eslint-disable no-unused-vars */
-  pageview(payload) {
+  customEvent(payload, customEventName = 'pageview') {
     return this.ensureScriptHasLoaded().then(() => (
-      this.updateTinypass(this.generatePayload(payload, 'pageview'))
-    )).catch((pageViewError) => {
+      this.updateTinypass(this.generatePayload(payload, customEventName))
+    )).catch((customEventError) => {
       /* eslint-disable no-console */
-      console.error(pageViewError.stack);
+      console.error(customEventError.stack);
       /* eslint-enable no-console */
     });
+  }
+  /* eslint-enable no-unused-vars */
+
+  /* eslint-disable no-unused-vars */
+  pageview(payload) {
+    return this.customEvent(payload);
+  }
+  /* eslint-enable no-unused-vars */
+
+  // Piano experiences could be evaluated in relation to a user status change.
+  // The user status change on SPA could be not connected to a pageview event.
+  /* eslint-disable no-unused-vars */
+  userinformationchange(payload) {
+    return this.customEvent(payload, 'userinformationchange');
   }
   /* eslint-enable no-unused-vars */
 

--- a/src/index.js
+++ b/src/index.js
@@ -90,32 +90,26 @@ export default class ReactInstrumentationPiano {
     return props;
   }
 
-  /* eslint-disable no-unused-vars */
   customEvent(payload, customEventName = 'pageview') {
-    return this.ensureScriptHasLoaded().then(() => (
-      this.updateTinypass(this.generatePayload(payload, customEventName))
-    )).catch((customEventError) => {
+    return this.ensureScriptHasLoaded().then(() => {
+      this.generatePayload(payload, customEventName);
+      this.updateTinypass();
+    }).catch((customEventError) => {
       /* eslint-disable no-console */
       console.error(customEventError.stack);
       /* eslint-enable no-console */
     });
   }
-  /* eslint-enable no-unused-vars */
 
-  /* eslint-disable no-unused-vars */
   pageview(payload) {
     return this.customEvent(payload);
   }
-  /* eslint-enable no-unused-vars */
 
   // Piano experiences could be evaluated in relation to a user status change.
   // The user status change on SPA could be not connected to a pageview event.
-  /* eslint-disable no-unused-vars */
   userinformationchange(payload) {
     return this.customEvent(payload, 'userinformationchange');
   }
-  /* eslint-enable no-unused-vars */
-
   updateTinypass() {
     /* eslint-disable id-match, camelcase */
     return window.tp.experience.execute();

--- a/test/index.js
+++ b/test/index.js
@@ -42,11 +42,12 @@ describe('PianoPlugin is a i13n plugin for Piano', () => {
         example: 'test',
       };
       plugin.updateTinypass = chai.spy();
-      plugin.generatePayload = chai.spy(() => 'payloadGenerated');
+      plugin.generatePayload = chai.spy();
       plugin.customEvent(payload, 'pageview').then(() => {
         plugin.ensureScriptHasLoaded.should.have.been.called.exactly(1);
         plugin.updateTinypass.should.have.been.called.exactly(1);
-        plugin.updateTinypass.should.have.been.called.with('payloadGenerated');
+        plugin.generatePayload.should.have.been.called.exactly(1);
+        plugin.generatePayload.should.have.been.called.with(payload, 'pageview');
         done();
       })
       .catch((error) => {

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ describe('PianoPlugin is a i13n plugin for Piano', () => {
       const loadExternalScript = chai.spy(() => Promise.resolve());
       const plugin = new ReactI13nPiano({ ...PianoConfig, loadExternalScript });
       plugin.ensureScriptHasLoaded();
-      loadExternalScript.should.have.been.called(1);
+      loadExternalScript.should.have.been.called.exactly(1);
     });
   });
   describe('piano plugin', () => {
@@ -21,7 +21,7 @@ describe('PianoPlugin is a i13n plugin for Piano', () => {
       const TrackedApp = new ReactI13nPiano(PianoConfig);
       TrackedApp.updateTinypass = chai.spy(() => Promise.resolve());
       return TrackedApp.pageview().then(() => {
-        TrackedApp.updateTinypass.should.have.been.called(1);
+        TrackedApp.updateTinypass.should.have.been.called.exactly(1);
         const pianoTp = window.tp;
         pianoTp.should.have.property('aid', 'M3UZnikdix');
         pianoTp.should.have.property('customPageUrl', 'http://www.economist.com');
@@ -63,7 +63,7 @@ describe('PianoPlugin is a i13n plugin for Piano', () => {
       plugin.pageview({
         example: 'test',
       });
-      plugin.customEvent.should.have.been.called(1);
+      plugin.customEvent.should.have.been.called.exactly(1);
     });
   });
   describe('userinformationchange', () => {
@@ -75,7 +75,7 @@ describe('PianoPlugin is a i13n plugin for Piano', () => {
         example: 'test',
       };
       plugin.userinformationchange(payload);
-      plugin.customEvent.should.have.been.called(1);
+      plugin.customEvent.should.have.been.called.exactly(1);
       plugin.customEvent.should.have.been.called.with(payload, 'userinformationchange');
     });
   });


### PR DESCRIPTION
To make Piano work properly when the user status change on the SPA (with no refresh) we need an additional event handler.
Plus we need the capability to add additional listeners before the init listener is called.